### PR TITLE
fix: publicise generated enum maps to enable reuse

### DIFF
--- a/xml_annotation/example/xml_annotation_example.g.dart
+++ b/xml_annotation/example/xml_annotation_example.g.dart
@@ -6,7 +6,7 @@ part of 'xml_annotation_example.dart';
 // XmlEnumGenerator
 // **************************************************************************
 
-const _$LanguageEnumMap = {
+const $LanguageEnumMap = {
   Language.mandarin: 'Mandarin',
   Language.spanish: 'Spanish',
   Language.english: 'English',
@@ -185,7 +185,7 @@ void _$TitleBuildXmlChildren(Title instance, XmlBuilder builder,
     {Map<String, String> namespaces = const {}}) {
   final language = instance.language;
   final languageSerialized =
-      language != null ? _$LanguageEnumMap[language]! : null;
+      language != null ? $LanguageEnumMap[language]! : null;
   if (languageSerialized != null) {
     builder.attribute('lang', languageSerialized);
   }
@@ -208,12 +208,12 @@ Title _$TitleFromXmlElement(XmlElement element) {
   final text = element.getText();
   return Title(
       language: language != null
-          ? _$LanguageEnumMap.entries
+          ? $LanguageEnumMap.entries
               .singleWhere(
                   (languageEnumMapEntry) =>
                       languageEnumMapEntry.value == language,
                   orElse: () => throw ArgumentError(
-                      '`$language` is not one of the supported values: ${_$LanguageEnumMap.values.join(', ')}'))
+                      '`$language` is not one of the supported values: ${$LanguageEnumMap.values.join(', ')}'))
               .key
           : null,
       text: text);
@@ -224,7 +224,7 @@ List<XmlAttribute> _$TitleToXmlAttributes(Title instance,
   final attributes = <XmlAttribute>[];
   final language = instance.language;
   final languageSerialized =
-      language != null ? _$LanguageEnumMap[language]! : null;
+      language != null ? $LanguageEnumMap[language]! : null;
   final languageConstructed = languageSerialized != null
       ? XmlAttribute(XmlName('lang'), languageSerialized)
       : null;

--- a/xml_serializable/README.md
+++ b/xml_serializable/README.md
@@ -242,7 +242,7 @@ part of 'example.dart';
 // XmlEnumGenerator
 // **************************************************************************
 
-const _$LanguageEnumMap = {
+const $LanguageEnumMap = {
   Language.mandarin: 'Mandarin',
   Language.spanish: 'Spanish',
   Language.english: 'English',
@@ -421,7 +421,7 @@ void _$TitleBuildXmlChildren(Title instance, XmlBuilder builder,
     {Map<String, String> namespaces = const {}}) {
   final language = instance.language;
   final languageSerialized =
-      language != null ? _$LanguageEnumMap[language]! : null;
+      language != null ? $LanguageEnumMap[language]! : null;
   if (languageSerialized != null) {
     builder.attribute('lang', languageSerialized);
   }
@@ -444,12 +444,12 @@ Title _$TitleFromXmlElement(XmlElement element) {
   final text = element.getText();
   return Title(
       language: language != null
-          ? _$LanguageEnumMap.entries
+          ? $LanguageEnumMap.entries
               .singleWhere(
                   (languageEnumMapEntry) =>
                       languageEnumMapEntry.value == language,
                   orElse: () => throw ArgumentError(
-                      '`$language` is not one of the supported values: ${_$LanguageEnumMap.values.join(', ')}'))
+                      '`$language` is not one of the supported values: ${$LanguageEnumMap.values.join(', ')}'))
               .key
           : null,
       text: text);
@@ -460,7 +460,7 @@ List<XmlAttribute> _$TitleToXmlAttributes(Title instance,
   final attributes = <XmlAttribute>[];
   final language = instance.language;
   final languageSerialized =
-      language != null ? _$LanguageEnumMap[language]! : null;
+      language != null ? $LanguageEnumMap[language]! : null;
   final languageConstructed = languageSerialized != null
       ? XmlAttribute(XmlName('lang'), languageSerialized)
       : null;

--- a/xml_serializable/example/xml_serializable_example.g.dart
+++ b/xml_serializable/example/xml_serializable_example.g.dart
@@ -6,7 +6,7 @@ part of 'xml_serializable_example.dart';
 // XmlEnumGenerator
 // **************************************************************************
 
-const _$LanguageEnumMap = {
+const $LanguageEnumMap = {
   Language.mandarin: 'Mandarin',
   Language.spanish: 'Spanish',
   Language.english: 'English',
@@ -185,7 +185,7 @@ void _$TitleBuildXmlChildren(Title instance, XmlBuilder builder,
     {Map<String, String> namespaces = const {}}) {
   final language = instance.language;
   final languageSerialized =
-      language != null ? _$LanguageEnumMap[language]! : null;
+      language != null ? $LanguageEnumMap[language]! : null;
   if (languageSerialized != null) {
     builder.attribute('lang', languageSerialized);
   }
@@ -208,12 +208,12 @@ Title _$TitleFromXmlElement(XmlElement element) {
   final text = element.getText();
   return Title(
       language: language != null
-          ? _$LanguageEnumMap.entries
+          ? $LanguageEnumMap.entries
               .singleWhere(
                   (languageEnumMapEntry) =>
                       languageEnumMapEntry.value == language,
                   orElse: () => throw ArgumentError(
-                      '`$language` is not one of the supported values: ${_$LanguageEnumMap.values.join(', ')}'))
+                      '`$language` is not one of the supported values: ${$LanguageEnumMap.values.join(', ')}'))
               .key
           : null,
       text: text);
@@ -224,7 +224,7 @@ List<XmlAttribute> _$TitleToXmlAttributes(Title instance,
   final attributes = <XmlAttribute>[];
   final language = instance.language;
   final languageSerialized =
-      language != null ? _$LanguageEnumMap[language]! : null;
+      language != null ? $LanguageEnumMap[language]! : null;
   final languageConstructed = languageSerialized != null
       ? XmlAttribute(XmlName('lang'), languageSerialized)
       : null;

--- a/xml_serializable/lib/src/serializer_generators/enum_serializer_generator.dart
+++ b/xml_serializable/lib/src/serializer_generators/enum_serializer_generator.dart
@@ -22,7 +22,7 @@ class EnumSerializerGenerator extends SerializerGenerator {
       buffer.write('$expression != null ? ');
     }
 
-    buffer.write('_\$${_name}EnumMap[$expression]!');
+    buffer.write('\$${_name}EnumMap[$expression]!');
 
     if (_isNullable) {
       buffer.write(' : null');
@@ -40,7 +40,7 @@ class EnumSerializerGenerator extends SerializerGenerator {
     }
 
     buffer.write(
-      '_\$${_name}EnumMap.entries.singleWhere((${_name.camelCase}EnumMapEntry) => ${_name.camelCase}EnumMapEntry.value == $expression, orElse: () => throw ArgumentError(\'`\$$expression` is not one of the supported values: \${_\$${_name}EnumMap.values.join(\', \')}\')).key',
+      '\$${_name}EnumMap.entries.singleWhere((${_name.camelCase}EnumMapEntry) => ${_name.camelCase}EnumMapEntry.value == $expression, orElse: () => throw ArgumentError(\'`\$$expression` is not one of the supported values: \${\$${_name}EnumMap.values.join(\', \')}\')).key',
     );
 
     if (_isNullable) {

--- a/xml_serializable/lib/src/xml_enum_generator.dart
+++ b/xml_serializable/lib/src/xml_enum_generator.dart
@@ -30,6 +30,6 @@ class XmlEnumGenerator extends GeneratorForAnnotation<XmlEnum> {
       );
     }
 
-    return 'const _\$${element.name}EnumMap = { ${element.fields.where((e) => e.isEnumConstant).map((e) => '${element.name}.${e.name}: \'${e.hasXmlValue ? e.getXmlValue()!.toXmlValueValue()!.value : e.getEncodedFieldName()}\'').join(', ')} };';
+    return 'const \$${element.name}EnumMap = { ${element.fields.where((e) => e.isEnumConstant).map((e) => '${element.name}.${e.name}: \'${e.hasXmlValue ? e.getXmlValue()!.toXmlValueValue()!.value : e.getEncodedFieldName()}\'').join(', ')} };';
   }
 }

--- a/xml_serializable/test/serializer_generators/enum_serializer_generator_test.dart
+++ b/xml_serializable/test/serializer_generators/enum_serializer_generator_test.dart
@@ -14,7 +14,7 @@ void main() {
               expect(
                 EnumSerializerGenerator('FooBar').generateSerializer('value'),
                 equals(
-                  '_\$FooBarEnumMap[value]!',
+                  '\$FooBarEnumMap[value]!',
                 ),
               );
             },
@@ -27,7 +27,7 @@ void main() {
                 NullableEnumSerializerGenerator('FooBar')
                     .generateSerializer('value'),
                 equals(
-                  'value != null ? _\$FooBarEnumMap[value]! : null',
+                  'value != null ? \$FooBarEnumMap[value]! : null',
                 ),
               );
             },
@@ -44,7 +44,7 @@ void main() {
               expect(
                 EnumSerializerGenerator('FooBar').generateDeserializer('value'),
                 equals(
-                  '_\$FooBarEnumMap.entries.singleWhere((fooBarEnumMapEntry) => fooBarEnumMapEntry.value == value, orElse: () => throw ArgumentError(\'`\$value` is not one of the supported values: \${_\$FooBarEnumMap.values.join(\', \')}\')).key',
+                  '\$FooBarEnumMap.entries.singleWhere((fooBarEnumMapEntry) => fooBarEnumMapEntry.value == value, orElse: () => throw ArgumentError(\'`\$value` is not one of the supported values: \${\$FooBarEnumMap.values.join(\', \')}\')).key',
                 ),
               );
             },
@@ -57,7 +57,7 @@ void main() {
                 NullableEnumSerializerGenerator('FooBar')
                     .generateDeserializer('value'),
                 equals(
-                  'value != null ? _\$FooBarEnumMap.entries.singleWhere((fooBarEnumMapEntry) => fooBarEnumMapEntry.value == value, orElse: () => throw ArgumentError(\'`\$value` is not one of the supported values: \${_\$FooBarEnumMap.values.join(\', \')}\')).key : null',
+                  'value != null ? \$FooBarEnumMap.entries.singleWhere((fooBarEnumMapEntry) => fooBarEnumMapEntry.value == value, orElse: () => throw ArgumentError(\'`\$value` is not one of the supported values: \${\$FooBarEnumMap.values.join(\', \')}\')).key : null',
                 ),
               );
             },

--- a/xml_serializable/test/xml_enum_generator_test.dart
+++ b/xml_serializable/test/xml_enum_generator_test.dart
@@ -45,7 +45,7 @@ void main() {
               FakeBuildStep(),
             ),
             equals(
-              '''const _\$FooBarEnumMap = { FooBar.foo: 'foo', FooBar.bar: 'Bar' };''',
+              '''const \$FooBarEnumMap = { FooBar.foo: 'foo', FooBar.bar: 'Bar' };''',
             ),
           );
         },
@@ -95,7 +95,7 @@ void main() {
               FakeBuildStep(),
             ),
             equals(
-              '''const _\$FooBarEnumMap = { FooBar.foo: 'Foo', FooBar.bar: 'bar' };''',
+              '''const \$FooBarEnumMap = { FooBar.foo: 'Foo', FooBar.bar: 'bar' };''',
             ),
           );
         },

--- a/xml_serializable/test/xml_serializable_generator_test.dart
+++ b/xml_serializable/test/xml_serializable_generator_test.dart
@@ -532,7 +532,7 @@ final dynamicAttribute = instance.dynamicAttribute;
 final dynamicAttributeSerialized = dynamicAttribute;
 if (dynamicAttributeSerialized != null) { builder.attribute('dynamicattribute', dynamicAttributeSerialized); }
 final enumAttribute = instance.enumAttribute;
-final enumAttributeSerialized = enumAttribute != null ? _\$FooBarEnumMap[enumAttribute]! : null;
+final enumAttributeSerialized = enumAttribute != null ? \$FooBarEnumMap[enumAttribute]! : null;
 if (enumAttributeSerialized != null) { builder.attribute('enumattribute', enumAttributeSerialized); }
 final intAttribute = instance.intAttribute;
 final intAttributeSerialized = intAttribute?.toString();
@@ -553,10 +553,10 @@ final customIterableElement = instance.customIterableElement;
 final customIterableElementSerialized = customIterableElement;
 if (customIterableElementSerialized != null) { for (final value in customIterableElementSerialized) { builder.element('customiterableelement', nest: () { value.buildXmlChildren(builder, namespaces: namespaces); }); } }
 final enumElement = instance.enumElement;
-final enumElementSerialized = enumElement != null ? _\$FooBarEnumMap[enumElement]! : null;
+final enumElementSerialized = enumElement != null ? \$FooBarEnumMap[enumElement]! : null;
 builder.element('enumelement', nest: () { if (enumElementSerialized != null) { builder.text(enumElementSerialized); } });
 final enumIterableElement = instance.enumIterableElement;
-final enumIterableElementSerialized = enumIterableElement?.map((e) => _\$FooBarEnumMap[e]!);
+final enumIterableElementSerialized = enumIterableElement?.map((e) => \$FooBarEnumMap[e]!);
 if (enumIterableElementSerialized != null) { for (final value in enumIterableElementSerialized) { builder.element('enumiterableelement', nest: () { builder.text(value); }); } }
 final stringElement = instance.stringElement;
 final stringElementSerialized = stringElement;
@@ -627,7 +627,7 @@ final stringSetElement = element.getElements('stringsetelement')?.map((e) => e.g
 final nonSelfClosingStringSetElement = element.getElements('nonselfclosingstringsetelement')?.map((e) => e.getText()).whereType<String>();
 final excludeIfNullStringSetElement = element.getElements('excludeifnullstringsetelement')?.map((e) => e.getText()).whereType<String>();
 final stringText = element.getText();
-return TestClass(boolAttribute: boolAttribute != null ? boolAttribute == 'true' || boolAttribute == '1' ? true : boolAttribute == 'false' || boolAttribute == '0' ? false : throw FormatException('Invalid bool format', boolAttribute) : null, dateTimeAttribute: dateTimeAttribute != null ? DateTime.parse(dateTimeAttribute) : null, doubleAttribute: doubleAttribute != null ? double.parse(doubleAttribute) : null, durationAttribute: durationAttribute != null ? Duration(microseconds: int.parse(durationAttribute)) : null, dynamicAttribute: dynamicAttribute, enumAttribute: enumAttribute != null ? _\$FooBarEnumMap.entries.singleWhere((fooBarEnumMapEntry) => fooBarEnumMapEntry.value == enumAttribute, orElse: () => throw ArgumentError('`\$enumAttribute` is not one of the supported values: \${_\$FooBarEnumMap.values.join(', ')}')).key : null, intAttribute: intAttribute != null ? int.parse(intAttribute) : null, numAttribute: numAttribute != null ? num.parse(numAttribute) : null, stringAttribute: stringAttribute, uriAttribute: uriAttribute != null ? Uri.parse(uriAttribute) : null, customElement: customElement != null ? CustomClass.fromXmlElement(customElement) : null, customIterableElement: customIterableElement?.map((e) => CustomClass.fromXmlElement(e)), enumElement: enumElement != null ? _\$FooBarEnumMap.entries.singleWhere((fooBarEnumMapEntry) => fooBarEnumMapEntry.value == enumElement, orElse: () => throw ArgumentError('`\$enumElement` is not one of the supported values: \${_\$FooBarEnumMap.values.join(', ')}')).key : null, enumIterableElement: enumIterableElement?.map((e) => _\$FooBarEnumMap.entries.singleWhere((fooBarEnumMapEntry) => fooBarEnumMapEntry.value == e, orElse: () => throw ArgumentError('`\$e` is not one of the supported values: \${_\$FooBarEnumMap.values.join(', ')}')).key), stringElement: stringElement, nonSelfClosingStringElement: nonSelfClosingStringElement, excludeIfNullStringElement: excludeIfNullStringElement, stringIterableElement: stringIterableElement, nonSelfClosingStringIterableElement: nonSelfClosingStringIterableElement, excludeIfNullStringIterableElement: excludeIfNullStringIterableElement, stringListElement: stringListElement?.toList(), nonSelfClosingStringListElement: nonSelfClosingStringListElement?.toList(), excludeIfNullStringListElement: excludeIfNullStringListElement?.toList(), stringSetElement: stringSetElement?.toSet(), nonSelfClosingStringSetElement: nonSelfClosingStringSetElement?.toSet(), excludeIfNullStringSetElement: excludeIfNullStringSetElement?.toSet(), stringText: stringText);
+return TestClass(boolAttribute: boolAttribute != null ? boolAttribute == 'true' || boolAttribute == '1' ? true : boolAttribute == 'false' || boolAttribute == '0' ? false : throw FormatException('Invalid bool format', boolAttribute) : null, dateTimeAttribute: dateTimeAttribute != null ? DateTime.parse(dateTimeAttribute) : null, doubleAttribute: doubleAttribute != null ? double.parse(doubleAttribute) : null, durationAttribute: durationAttribute != null ? Duration(microseconds: int.parse(durationAttribute)) : null, dynamicAttribute: dynamicAttribute, enumAttribute: enumAttribute != null ? \$FooBarEnumMap.entries.singleWhere((fooBarEnumMapEntry) => fooBarEnumMapEntry.value == enumAttribute, orElse: () => throw ArgumentError('`\$enumAttribute` is not one of the supported values: \${\$FooBarEnumMap.values.join(', ')}')).key : null, intAttribute: intAttribute != null ? int.parse(intAttribute) : null, numAttribute: numAttribute != null ? num.parse(numAttribute) : null, stringAttribute: stringAttribute, uriAttribute: uriAttribute != null ? Uri.parse(uriAttribute) : null, customElement: customElement != null ? CustomClass.fromXmlElement(customElement) : null, customIterableElement: customIterableElement?.map((e) => CustomClass.fromXmlElement(e)), enumElement: enumElement != null ? \$FooBarEnumMap.entries.singleWhere((fooBarEnumMapEntry) => fooBarEnumMapEntry.value == enumElement, orElse: () => throw ArgumentError('`\$enumElement` is not one of the supported values: \${\$FooBarEnumMap.values.join(', ')}')).key : null, enumIterableElement: enumIterableElement?.map((e) => \$FooBarEnumMap.entries.singleWhere((fooBarEnumMapEntry) => fooBarEnumMapEntry.value == e, orElse: () => throw ArgumentError('`\$e` is not one of the supported values: \${\$FooBarEnumMap.values.join(', ')}')).key), stringElement: stringElement, nonSelfClosingStringElement: nonSelfClosingStringElement, excludeIfNullStringElement: excludeIfNullStringElement, stringIterableElement: stringIterableElement, nonSelfClosingStringIterableElement: nonSelfClosingStringIterableElement, excludeIfNullStringIterableElement: excludeIfNullStringIterableElement, stringListElement: stringListElement?.toList(), nonSelfClosingStringListElement: nonSelfClosingStringListElement?.toList(), excludeIfNullStringListElement: excludeIfNullStringListElement?.toList(), stringSetElement: stringSetElement?.toSet(), nonSelfClosingStringSetElement: nonSelfClosingStringSetElement?.toSet(), excludeIfNullStringSetElement: excludeIfNullStringSetElement?.toSet(), stringText: stringText);
 }
 
 List<XmlAttribute> _\$TestClassToXmlAttributes(TestClass instance, {Map<String, String?> namespaces = const {}}) {
@@ -653,7 +653,7 @@ final dynamicAttributeSerialized = dynamicAttribute;
 final dynamicAttributeConstructed = dynamicAttributeSerialized != null ? XmlAttribute(XmlName('dynamicattribute'), dynamicAttributeSerialized) : null;
 if (dynamicAttributeConstructed != null) { attributes.add(dynamicAttributeConstructed); }
 final enumAttribute = instance.enumAttribute;
-final enumAttributeSerialized = enumAttribute != null ? _\$FooBarEnumMap[enumAttribute]! : null;
+final enumAttributeSerialized = enumAttribute != null ? \$FooBarEnumMap[enumAttribute]! : null;
 final enumAttributeConstructed = enumAttributeSerialized != null ? XmlAttribute(XmlName('enumattribute'), enumAttributeSerialized) : null;
 if (enumAttributeConstructed != null) { attributes.add(enumAttributeConstructed); }
 final intAttribute = instance.intAttribute;
@@ -686,11 +686,11 @@ final customIterableElementSerialized = customIterableElement;
 final customIterableElementConstructed = customIterableElementSerialized?.map((e) => XmlElement(XmlName('customiterableelement'), e.toXmlAttributes(namespaces: namespaces), e.toXmlChildren(namespaces: namespaces)));
 if (customIterableElementConstructed != null) { children.addAll(customIterableElementConstructed); }
 final enumElement = instance.enumElement;
-final enumElementSerialized = enumElement != null ? _\$FooBarEnumMap[enumElement]! : null;
+final enumElementSerialized = enumElement != null ? \$FooBarEnumMap[enumElement]! : null;
 final enumElementConstructed = XmlElement(XmlName('enumelement'), [], enumElementSerialized != null ? [XmlText(enumElementSerialized)] : []);
 children.add(enumElementConstructed);
 final enumIterableElement = instance.enumIterableElement;
-final enumIterableElementSerialized = enumIterableElement?.map((e) => _\$FooBarEnumMap[e]!);
+final enumIterableElementSerialized = enumIterableElement?.map((e) => \$FooBarEnumMap[e]!);
 final enumIterableElementConstructed = enumIterableElementSerialized?.map((e) => XmlElement(XmlName('enumiterableelement'), [], [XmlText(e)]));
 if (enumIterableElementConstructed != null) { children.addAll(enumIterableElementConstructed); }
 final stringElement = instance.stringElement;


### PR DESCRIPTION
**Describe the change**
Replace all occurances of `_$XXXEnumMap` with `$XXXEnumMap`.

**Current behavior**
Enum maps are library private, making it impossible to reuse enums across multiple files.

**New behavior**
Enums files are now library public, allowing to spread them into multiple files and reuse them for multiple elements.

**Additional context**
Fixes #28 

I did update and run all tests and regenerated the example .g files to ensure the changes work