### PR TITLE
add support for XmlCDATA text

### DIFF
--- a/xml_annotation/lib/src/extensions/xml_node_extensions.dart
+++ b/xml_annotation/lib/src/extensions/xml_node_extensions.dart
@@ -37,9 +37,11 @@ extension XmlNodeExtensions on XmlNode {
     return elements.isNotEmpty ? elements : null;
   }
 
-  /// Gets the text or `null` if there are no `XmlText` children.
+  /// Gets the text or `null` if there are no `XmlText` and `XmlCDATA` children.
   String? getText() {
-    final texts = children.whereType<XmlText>().map((e) => e.text);
+    final texts = children
+        .where((element) => [XmlText, XmlCDATA].contains(element.runtimeType))
+        .map((e) => e.text);
     return texts.isNotEmpty ? texts.join() : null;
   }
 }

--- a/xml_annotation/lib/src/extensions/xml_node_extensions.dart
+++ b/xml_annotation/lib/src/extensions/xml_node_extensions.dart
@@ -41,7 +41,7 @@ extension XmlNodeExtensions on XmlNode {
   String? getText() {
     final texts = children
         .where((element) => [XmlText, XmlCDATA].contains(element.runtimeType))
-        .map((e) => e.text);
+        .map((e) => e.text.trim());
     return texts.isNotEmpty ? texts.join() : null;
   }
 }


### PR DESCRIPTION
**Describe the change**
I've implemented support for extracting text from **XmlCDATA** children.

**Current behavior**
Currently only extracting text from **XmlText** children is supported.

**New behavior**
Now **getText** method returns both text from **XmlText** and **XmlCDATA** children. The text is also trimmed because **XmlCDATA** elements contain leading and trailing whitespace.

**Additional context**
I'm not sure if this is the correct way to handle this. Maybe we could add another method only for handling **XmlCDATA** children?
